### PR TITLE
Foundry/presale

### DIFF
--- a/contracts/IPresale.sol
+++ b/contracts/IPresale.sol
@@ -7,7 +7,7 @@ interface IPresale {
 
     event RoundsUpdated(RoundConfig[] prevRounds, RoundConfig[] newRounds, address indexed sender);
 
-    event Receipt(
+    event Purchase(
         uint256 indexed roundIndex,
         address indexed asset,
         uint256 tokenPrice,

--- a/contracts/IPresale.sol
+++ b/contracts/IPresale.sol
@@ -8,8 +8,8 @@ interface IPresale {
     event RoundsUpdated(RoundConfig[] prevRounds, RoundConfig[] newRounds, address indexed sender);
 
     event Receipt(
-        address indexed asset,
         uint256 indexed roundIndex,
+        address indexed asset,
         uint256 tokenPrice,
         uint256 amountAsset,
         uint256 amountUSD,

--- a/contracts/Presale.sol
+++ b/contracts/Presale.sol
@@ -177,8 +177,13 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
         uint256 _totalAllocation;
         uint256 _totalPurchaseAmountAsset;
 
+        address _asset = purchaseConfig.asset;
+        uint256 _amountAsset = purchaseConfig.amountAsset;
+        uint256 _amountUSD = purchaseConfig.amountUSD;
+        address _account = purchaseConfig.account;
+
         uint256 _remainingUSD = purchaseConfig.amountUSD;
-        uint256 _userAllocationRemaining = _config.maxUserAllocation - $userTokensAllocated[purchaseConfig.account];
+        uint256 _userAllocationRemaining = _config.maxUserAllocation - $userTokensAllocated[_account];
 
         uint256 i = $currentRoundIndex;
         for (i; i < _rounds.length && _remainingUSD > 0 && _userAllocationRemaining > 0; ++i) {
@@ -206,20 +211,20 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
             _userAllocationRemaining -= _roundAllocation;
             _totalAllocation += _roundAllocation;
 
-            uint256 _roundPurchaseAmountAsset = _tokensCostUSD * purchaseConfig.amountAsset / purchaseConfig.amountUSD;
+            uint256 _roundPurchaseAmountAsset = _tokensCostUSD * _amountAsset / _amountUSD;
             _totalPurchaseAmountAsset += _roundPurchaseAmountAsset;
 
             $roundAllocated[i] += _roundAllocation;
             $totalRaisedUSD += _tokensCostUSD;
 
             emit Receipt(
-                purchaseConfig.asset,
+                _asset,
                 i,
                 _round.tokenPrice,
                 _roundPurchaseAmountAsset,
                 _tokensCostUSD,
                 _roundAllocation,
-                purchaseConfig.account
+                _account
             );
         }
 
@@ -227,17 +232,17 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
 
         $currentRoundIndex = i;
 
-        $userTokensAllocated[purchaseConfig.account] = _config.maxUserAllocation - _userAllocationRemaining;
+        $userTokensAllocated[_account] = _config.maxUserAllocation - _userAllocationRemaining;
 
-        uint256 _refundAmountAsset = purchaseConfig.amountAsset - _totalPurchaseAmountAsset;
+        uint256 _refundAmountAsset = _amountAsset - _totalPurchaseAmountAsset;
 
         if (_refundAmountAsset > 0) {
-            _send(purchaseConfig.asset, _refundAmountAsset, payable(purchaseConfig.account));
-            emit Refund(purchaseConfig.asset, _refundAmountAsset, _remainingUSD, purchaseConfig.account);
+            _send(_asset, _refundAmountAsset, payable(_account));
+            emit Refund(_asset, _refundAmountAsset, _remainingUSD, _account);
         }
 
         if (_totalPurchaseAmountAsset > 0) {
-            _send(purchaseConfig.asset, _totalPurchaseAmountAsset, _config.withdrawTo);
+            _send(_asset, _totalPurchaseAmountAsset, _config.withdrawTo);
         }
 
         return _totalAllocation;

--- a/contracts/Presale.sol
+++ b/contracts/Presale.sol
@@ -250,7 +250,7 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
 
         require(_totalAllocation > 0, "MIN_ALLOCATION");
 
-        $currentRoundIndex = i;
+        $currentRoundIndex = i < _rounds.length ? i : _rounds.length - 1;
 
         $userTokensAllocated[purchaseConfig.account] = _config.maxUserAllocation - _userAllocationRemaining;
 

--- a/contracts/Presale.sol
+++ b/contracts/Presale.sol
@@ -240,9 +240,12 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
             );
         }
 
-        require(_totalAllocation > 0, "MIN_ALLOCATION");
+        uint256 _finalRoundIndex = _rounds.length - 1;
+        bool isSoldOut = $roundAllocated[_finalRoundIndex] == $rounds[_finalRoundIndex].tokensAllocated;
 
-        $currentRoundIndex = i < _rounds.length ? i : _rounds.length - 1;
+        require(_totalAllocation > 0 || isSoldOut, "MIN_ALLOCATION");
+
+        $currentRoundIndex = i < _rounds.length ? i : _finalRoundIndex;
 
         $userTokensAllocated[purchaseConfig.account] = _config.maxUserAllocation - _userAllocationRemaining;
 

--- a/contracts/Presale.sol
+++ b/contracts/Presale.sol
@@ -125,6 +125,8 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
     function purchase(address account) public payable override whenNotPaused returns (uint256 allocation) {
         uint256 _amountUSD = ethToUsd(msg.value);
 
+        console.log("_amountUSD", _amountUSD);
+
         PurchaseConfig memory _purchaseConfig =
             PurchaseConfig({asset: address(0), amountAsset: msg.value, amountUSD: _amountUSD, account: account});
 
@@ -179,13 +181,8 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
         uint256 _totalAllocation;
         uint256 _totalPurchaseAmountAsset;
 
-        address _asset = purchaseConfig.asset;
-        uint256 _amountAsset = purchaseConfig.amountAsset;
-        uint256 _amountUSD = purchaseConfig.amountUSD;
-        address _account = purchaseConfig.account;
-
         uint256 _remainingUSD = purchaseConfig.amountUSD;
-        uint256 _userAllocationRemaining = _config.maxUserAllocation - $userTokensAllocated[_account];
+        uint256 _userAllocationRemaining = _config.maxUserAllocation - $userTokensAllocated[purchaseConfig.account];
 
         uint256 i = $currentRoundIndex;
         for (i; i < _rounds.length && _remainingUSD > 0 && _userAllocationRemaining > 0; ++i) {
@@ -196,7 +193,7 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
 
             if (_roundAllocationRemaining == 0) continue;
 
-            uint256 _roundAllocation = (_remainingUSD * PRECISION) / _round.tokenPrice;
+            uint256 _roundAllocation = _remainingUSD * PRECISION / _round.tokenPrice;
 
             if (_roundAllocation > _roundAllocationRemaining) {
                 _roundAllocation = _roundAllocationRemaining;
@@ -205,31 +202,37 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
                 _roundAllocation = _userAllocationRemaining;
             }
 
-            console.log('round', i);
-            console.log("_roundAllocation", _roundAllocation);
-            console.log("_remainingUSD", _remainingUSD);
-            console.log("_roundAllocationRemaining", _roundAllocationRemaining);
-            console.log("_userAllocationRemaining", _userAllocationRemaining);
-
             if (_roundAllocation == 0) {
+                --i;
                 break;
             }
 
+            console.log("_round", i);
+            console.log("_remainingUSD", _remainingUSD);
+            console.log("_roundAllocation", _roundAllocation);
+            console.log("_userAllocationRemaining", _userAllocationRemaining);
+            console.log("_roundAllocationRemaining", _roundAllocationRemaining);
+
             uint256 _tokensCostUSD = _roundAllocation * _round.tokenPrice / PRECISION;
-            console.log(_tokensCostUSD);
             _remainingUSD -= _tokensCostUSD;
 
             _userAllocationRemaining -= _roundAllocation;
             _totalAllocation += _roundAllocation;
 
-            uint256 _roundPurchaseAmountAsset = _tokensCostUSD * _amountAsset / _amountUSD;
+            uint256 _roundPurchaseAmountAsset = _tokensCostUSD * purchaseConfig.amountAsset / purchaseConfig.amountUSD;
             _totalPurchaseAmountAsset += _roundPurchaseAmountAsset;
 
             $roundAllocated[i] += _roundAllocation;
             $totalRaisedUSD += _tokensCostUSD;
 
             emit Receipt(
-                _asset, i, _round.tokenPrice, _roundPurchaseAmountAsset, _tokensCostUSD, _roundAllocation, _account
+                i,
+                purchaseConfig.asset,
+                _round.tokenPrice,
+                _roundPurchaseAmountAsset,
+                _tokensCostUSD,
+                _roundAllocation,
+                purchaseConfig.account
             );
         }
 
@@ -237,17 +240,17 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
 
         $currentRoundIndex = i;
 
-        $userTokensAllocated[_account] = _config.maxUserAllocation - _userAllocationRemaining;
+        $userTokensAllocated[purchaseConfig.account] = _config.maxUserAllocation - _userAllocationRemaining;
 
-        uint256 _refundAmountAsset = _amountAsset - _totalPurchaseAmountAsset;
+        uint256 _refundAmountAsset = purchaseConfig.amountAsset - _totalPurchaseAmountAsset;
 
         if (_refundAmountAsset > 0) {
-            _send(_asset, _refundAmountAsset, payable(_account));
-            emit Refund(_asset, _refundAmountAsset, _remainingUSD, _account);
+            _send(purchaseConfig.asset, _refundAmountAsset, payable(purchaseConfig.account));
+            emit Refund(purchaseConfig.asset, _refundAmountAsset, _remainingUSD, purchaseConfig.account);
         }
 
         if (_totalPurchaseAmountAsset > 0) {
-            _send(_asset, _totalPurchaseAmountAsset, _config.withdrawTo);
+            _send(purchaseConfig.asset, _totalPurchaseAmountAsset, _config.withdrawTo);
         }
 
         return _totalAllocation;

--- a/contracts/Presale.sol
+++ b/contracts/Presale.sol
@@ -218,13 +218,7 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
             $totalRaisedUSD += _tokensCostUSD;
 
             emit Receipt(
-                _asset,
-                i,
-                _round.tokenPrice,
-                _roundPurchaseAmountAsset,
-                _tokensCostUSD,
-                _roundAllocation,
-                _account
+                _asset, i, _round.tokenPrice, _roundPurchaseAmountAsset, _tokensCostUSD, _roundAllocation, _account
             );
         }
 

--- a/contracts/Presale.sol
+++ b/contracts/Presale.sol
@@ -11,6 +11,8 @@ import "@openzeppelin/contracts/security/Pausable.sol";
 
 import "./IPresale.sol";
 
+import "forge-std/console.sol";
+
 contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
     address public immutable USDC;
     address public immutable DAI;
@@ -194,7 +196,7 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
 
             if (_roundAllocationRemaining == 0) continue;
 
-            uint256 _roundAllocation = _remainingUSD * PRECISION / _round.tokenPrice;
+            uint256 _roundAllocation = (_remainingUSD * PRECISION) / _round.tokenPrice;
 
             if (_roundAllocation > _roundAllocationRemaining) {
                 _roundAllocation = _roundAllocationRemaining;
@@ -203,9 +205,18 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
                 _roundAllocation = _userAllocationRemaining;
             }
 
-            require(_roundAllocation > 0, "MIN_ROUND_ALLOCATION");
+            console.log('round', i);
+            console.log("_roundAllocation", _roundAllocation);
+            console.log("_remainingUSD", _remainingUSD);
+            console.log("_roundAllocationRemaining", _roundAllocationRemaining);
+            console.log("_userAllocationRemaining", _userAllocationRemaining);
+
+            if (_roundAllocation == 0) {
+                break;
+            }
 
             uint256 _tokensCostUSD = _roundAllocation * _round.tokenPrice / PRECISION;
+            console.log(_tokensCostUSD);
             _remainingUSD -= _tokensCostUSD;
 
             _userAllocationRemaining -= _roundAllocation;

--- a/contracts/Presale.sol
+++ b/contracts/Presale.sol
@@ -118,9 +118,11 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
         uint256 _expectedCurrentRoundIndex;
 
         for (uint256 i; i < newRounds.length; ++i) {
-            $rounds.push(newRounds[i]);
+            RoundConfig memory _newRound = newRounds[i];
 
-            uint256 _roundCostUSD = newRounds[i].tokensAllocated * newRounds[i].tokenPrice / PRECISION;
+            $rounds.push(_newRound);
+
+            uint256 _roundCostUSD = _newRound.tokensAllocated * _newRound.tokenPrice / PRECISION;
             _totalCostUSD += _roundCostUSD;
             if (_totalRaisedUSD > _totalCostUSD) {
                 _expectedCurrentRoundIndex++;
@@ -189,7 +191,7 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
         );
 
         uint256 _totalAllocation;
-        uint256 _totalPurchaseAmountAsset;
+        uint256 _totalCostAsset;
 
         uint256 _remainingUSD = purchaseConfig.amountUSD;
         uint256 _userAllocationRemaining = _config.maxUserAllocation - $userTokensAllocated[purchaseConfig.account];
@@ -224,7 +226,7 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
             _totalAllocation += _roundAllocation;
 
             uint256 _roundPurchaseAmountAsset = _tokensCostUSD * purchaseConfig.amountAsset / purchaseConfig.amountUSD;
-            _totalPurchaseAmountAsset += _roundPurchaseAmountAsset;
+            _totalCostAsset += _roundPurchaseAmountAsset;
 
             $roundAllocated[i] += _roundAllocation;
             $totalRaisedUSD += _tokensCostUSD;
@@ -249,15 +251,15 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
 
         $userTokensAllocated[purchaseConfig.account] = _config.maxUserAllocation - _userAllocationRemaining;
 
-        uint256 _refundAmountAsset = purchaseConfig.amountAsset - _totalPurchaseAmountAsset;
+        uint256 _refundAmountAsset = purchaseConfig.amountAsset - _totalCostAsset;
 
         if (_refundAmountAsset > 0) {
             _send(purchaseConfig.asset, _refundAmountAsset, payable(_msgSender()));
             emit Refund(purchaseConfig.asset, _refundAmountAsset, _remainingUSD, _msgSender());
         }
 
-        if (_totalPurchaseAmountAsset > 0) {
-            _send(purchaseConfig.asset, _totalPurchaseAmountAsset, _config.withdrawTo);
+        if (_totalCostAsset > 0) {
+            _send(purchaseConfig.asset, _totalCostAsset, _config.withdrawTo);
         }
 
         return _totalAllocation;

--- a/contracts/Presale.sol
+++ b/contracts/Presale.sol
@@ -11,8 +11,6 @@ import "@openzeppelin/contracts/security/Pausable.sol";
 
 import "./IPresale.sol";
 
-import "forge-std/console.sol";
-
 contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
     address public immutable USDC;
     address public immutable DAI;
@@ -219,12 +217,6 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
                 break;
             }
 
-            console.log("_round", i);
-            console.log("_remainingUSD", _remainingUSD);
-            console.log("_roundAllocation", _roundAllocation);
-            console.log("_userAllocationRemaining", _userAllocationRemaining);
-            console.log("_roundAllocationRemaining", _roundAllocationRemaining);
-
             uint256 _tokensCostUSD = _roundAllocation * _round.tokenPrice / PRECISION;
             _remainingUSD -= _tokensCostUSD;
 
@@ -257,8 +249,8 @@ contract Presale is IPresale, Ownable2Step, ReentrancyGuard, Pausable {
         uint256 _refundAmountAsset = purchaseConfig.amountAsset - _totalPurchaseAmountAsset;
 
         if (_refundAmountAsset > 0) {
-            _send(purchaseConfig.asset, _refundAmountAsset, payable(purchaseConfig.account));
-            emit Refund(purchaseConfig.asset, _refundAmountAsset, _remainingUSD, purchaseConfig.account);
+            _send(purchaseConfig.asset, _refundAmountAsset, payable(_msgSender()));
+            emit Refund(purchaseConfig.asset, _refundAmountAsset, _remainingUSD, _msgSender());
         }
 
         if (_totalPurchaseAmountAsset > 0) {

--- a/foundry/tests/Presale.t.sol
+++ b/foundry/tests/Presale.t.sol
@@ -9,6 +9,8 @@ import "contracts/PreSale.sol";
 import "../mocks/TestERC20.sol";
 import "../mocks/MockV3Aggregator.sol";
 
+import "forge-std/console.sol";
+
 contract PresaleTest is Test {
     Presale internal presale;
 
@@ -74,7 +76,7 @@ contract PresaleTest is Test {
         DAI.mint(BOB, 100_000 ether);
 
         config = IPresale.PresaleConfig({
-            minDepositAmount: 1,
+            minDepositAmount: 1 ether,
             maxUserAllocation: uint128(70_000 * PRECISION),
             startDate: startDate,
             endDate: endDate,
@@ -194,38 +196,25 @@ contract PresaleTest_roundAllocated is PresaleTest {
     }
 
     function test_success() external {
-        assertEq(presale.roundAllocated(0), tokensAllocated[0] * PRECISION);
+        assertEq(presale.roundAllocated(0), tokensAllocated[0]);
     }
 }
 
 contract PresaleTest_totalRaisedUSD is PresaleTest {
     uint256 private _totalCostUSD;
-    uint256[] private purchaseAmountsUSD;
+    uint256[] private _purchaseAmountsUSD;
 
     function setUp() public {
         vm.warp(startDate + 1);
 
-        purchaseAmountsUSD = [700, 700, 800, 800, 100];
+        _purchaseAmountsUSD = [700, 700, 800, 100];
 
-        //        uint256 _round1PurchaseAmountUSD = 700 * USD_PRECISION;
-        //        uint256 _round2PurchaseAmountUSD = 700 * USD_PRECISION;
-        //        uint256 _round3PurchaseAmountUSD = 800 * USD_PRECISION;
-        //        uint256 _round4PurchaseAmountUSD = 100 * USD_PRECISION;
-        //
-        //        uint256 _round1Allocation = _round1PurchaseAmountUSD * PRECISION / rounds[0].tokenPrice;
-        //        uint256 _round2Allocation = _round2PurchaseAmountUSD * PRECISION / rounds[1].tokenPrice;
-        //        uint256 _round3Allocation = _round3PurchaseAmountUSD * PRECISION / rounds[2].tokenPrice;
-        //        uint256 _round4Allocation = _round4PurchaseAmountUSD * PRECISION / rounds[3].tokenPrice;
-        //
-        //        uint256 _round1CostUSD = _round1PurchaseAmountUSD * rounds[0].tokenPrice / PRECISION;
-        //        uint256 _round2CostUSD = _round2PurchaseAmountUSD * rounds[1].tokenPrice / PRECISION;
-        //        uint256 _round3CostUSD = _round3PurchaseAmountUSD * rounds[2].tokenPrice / PRECISION;
-        //        uint256 _round4CostUSD = _round4PurchaseAmountUSD * rounds[3].tokenPrice / PRECISION;
-        //
-        //        _totalCostUSD += _round1CostUSD;
-        //        _totalCostUSD += _round2CostUSD;
-        //        _totalCostUSD += _round3CostUSD;
-        //        _totalCostUSD += _round4CostUSD;
+        for (uint256 i; i < _purchaseAmountsUSD.length; ++i) {
+            IPresale.RoundConfig memory _round = presale.round(i);
+            uint256 _roundAllocation = _purchaseAmountsUSD[i] * (USD_PRECISION * PRECISION) / _round.tokenPrice;
+            uint256 _tokenCostUSD = _roundAllocation * _round.tokenPrice / PRECISION;
+            _totalCostUSD += _tokenCostUSD;
+        }
 
         vm.prank(ALICE);
         presale.purchaseUSDC(2300 * 1e6);
@@ -237,70 +226,392 @@ contract PresaleTest_totalRaisedUSD is PresaleTest {
 }
 
 contract PresaleTest_userTokensAllocated is PresaleTest {
-    function test_success() external {}
+    uint256 private _totalUserAllocation;
+    uint256[] private _purchaseAmountsUSD;
+
+    function setUp() public {
+        vm.warp(startDate + 1);
+
+        _purchaseAmountsUSD = [700, 700, 800, 100];
+
+        for (uint256 i; i < _purchaseAmountsUSD.length; ++i) {
+            IPresale.RoundConfig memory _round = presale.round(i);
+            uint256 _roundAllocation = _purchaseAmountsUSD[i] * (USD_PRECISION * PRECISION) / _round.tokenPrice;
+            _totalUserAllocation += _roundAllocation;
+        }
+
+        vm.prank(ALICE);
+        presale.purchase{value: 115 * 1e16}();
+    }
+
+    function test_success() external {
+        assertEq(presale.userTokensAllocated(ALICE), _totalUserAllocation);
+    }
 }
 
 contract PresaleTest_ethPrice is PresaleTest {
-    function test_success() external {}
+    function test_success() external {
+        assertEq(presale.ethPrice(), 2_000 * PRECISION);
+    }
 }
 
 contract PresaleTest_ethToUsd is PresaleTest {
-    function test_success() external {}
+    function test_success() external {
+        uint256 _ethAmount = 2 * USD_PRECISION;
+        uint256 _usdAmount = _ethAmount * presale.ethPrice() / PRECISION;
+        assertEq(presale.ethToUsd(_ethAmount), _usdAmount);
+    }
+}
+
+contract PresaleTest_ethToTokens is PresaleTest {
+    function test_success() external {
+        IPresale.RoundConfig memory _round = presale.round(0);
+        uint256 _ethAmount = 2 * USD_PRECISION;
+        uint256 _usdAmount = _ethAmount * presale.ethPrice() / PRECISION;
+        uint256 _tokenAmount = _usdAmount * _round.tokenPrice / (USD_PRECISION * PRECISION);
+        assertEq(presale.ethToTokens(0, _ethAmount), _tokenAmount);
+    }
 }
 
 contract PresaleTest_usdToTokens is PresaleTest {
-    function test_success() external {}
+    function test_success() external {
+        IPresale.RoundConfig memory _round = presale.round(0);
+        uint256 _usdAmount = 100 * USD_PRECISION;
+        uint256 _tokenAmount = _usdAmount * _round.tokenPrice / USD_PRECISION;
+        assertEq(presale.usdToTokens(0, _usdAmount), _tokenAmount);
+    }
+}
+
+contract PresaleTest_pause is PresaleTest {
+    event Paused(address account);
+
+    function test_success() external {
+        vm.prank(GLOBAL_ADMIN);
+        presale.pause();
+
+        assertTrue(presale.paused());
+    }
+
+    function test_rejects_whenPaused() external {
+        vm.startPrank(GLOBAL_ADMIN);
+        presale.pause();
+
+        vm.expectRevert("Pausable: paused");
+        presale.pause();
+
+        vm.stopPrank();
+    }
+
+    function test_rejects_whenNotOwner() external {
+        vm.expectRevert("Ownable: caller is not the owner");
+
+        vm.prank(ALICE);
+        presale.pause();
+    }
+
+    function test_emits_Paused() external assertEvent {
+        vm.prank(GLOBAL_ADMIN);
+        emit Paused(GLOBAL_ADMIN);
+        presale.pause();
+    }
+}
+
+contract PresaleTest_unpause is PresaleTest {
+    event Unpaused(address account);
+
+    function setUp() public {
+        vm.prank(GLOBAL_ADMIN);
+        presale.pause();
+    }
+
+    function test_success() external {
+        vm.prank(GLOBAL_ADMIN);
+        presale.unpause();
+        assertFalse(presale.paused());
+    }
+
+    function test_rejects_whenNotPaused() external {
+        vm.startPrank(GLOBAL_ADMIN);
+        presale.unpause();
+
+        vm.expectRevert("Pausable: not paused");
+        presale.unpause();
+
+        vm.stopPrank();
+    }
+
+    function test_rejects_whenNotOwner() external {
+        vm.expectRevert("Ownable: caller is not the owner");
+
+        vm.prank(ALICE);
+        presale.unpause();
+    }
+
+    function test_emits_Unpaused() external assertEvent {
+        vm.prank(GLOBAL_ADMIN);
+        emit Unpaused(GLOBAL_ADMIN);
+        presale.unpause();
+    }
 }
 
 contract PresaleTest_setConfig is PresaleTest {
-    function test_success() external {}
+    event ConfigUpdated(IPresale.PresaleConfig prevConfig, IPresale.PresaleConfig newConfig, address indexed sender);
 
-    function test_rejects_whenNotOwner() external {}
+    IPresale.PresaleConfig private _newConfig;
 
-    function test_rejects_whenInvalidDates() external {}
+    function setUp() public {
+        _newConfig = IPresale.PresaleConfig({
+            minDepositAmount: uint128(1 * USD_PRECISION),
+            maxUserAllocation: uint128(10_000 * PRECISION),
+            startDate: 1 days,
+            endDate: 10 days,
+            withdrawTo: GLOBAL_ADMIN
+        });
+    }
 
-    function test_rejects_whenInvalidWithdrawTo() external {}
+    function test_success() external {
+        vm.prank(GLOBAL_ADMIN);
 
-    function test_emit_ConfigUpdated() external {}
+        presale.setConfig(_newConfig);
+
+        IPresale.PresaleConfig memory _config = presale.config();
+
+        assertEq(_config.minDepositAmount, uint128(1 * USD_PRECISION));
+        assertEq(_config.maxUserAllocation, uint128(10_000 * PRECISION));
+        assertEq(_config.startDate, 1 days);
+        assertEq(_config.endDate, 10 days);
+        assertEq(_config.withdrawTo, GLOBAL_ADMIN);
+    }
+
+    function test_rejects_whenNotOwner() external {
+        vm.expectRevert("Ownable: caller is not the owner");
+
+        vm.prank(ALICE);
+        presale.setConfig(_newConfig);
+    }
+
+    function test_rejects_whenInvalidDates() external {
+        IPresale.PresaleConfig memory _invalidConfig = IPresale.PresaleConfig({
+            minDepositAmount: uint128(1 * USD_PRECISION),
+            maxUserAllocation: uint128(10_000 * PRECISION),
+            startDate: 10 days,
+            endDate: 1 days,
+            withdrawTo: GLOBAL_ADMIN
+        });
+
+        vm.expectRevert("INVALID_DATES");
+
+        vm.prank(GLOBAL_ADMIN);
+        presale.setConfig(_invalidConfig);
+    }
+
+    function test_rejects_whenInvalidWithdrawTo() external {
+        IPresale.PresaleConfig memory _invalidConfig = IPresale.PresaleConfig({
+            minDepositAmount: uint128(1 * USD_PRECISION),
+            maxUserAllocation: uint128(10_000 * PRECISION),
+            startDate: 1 days,
+            endDate: 10 days,
+            withdrawTo: payable(address(0))
+        });
+
+        vm.expectRevert("INVALID_WITHDRAW_TO");
+
+        vm.prank(GLOBAL_ADMIN);
+        presale.setConfig(_invalidConfig);
+    }
+
+    function test_emit_ConfigUpdated() external assertEvent {
+        IPresale.PresaleConfig memory _prevConfig = presale.config();
+        vm.prank(GLOBAL_ADMIN);
+        emit ConfigUpdated(_prevConfig, _newConfig, GLOBAL_ADMIN);
+        presale.setConfig(_newConfig);
+    }
 }
 
 contract PresaleTest_setRounds is PresaleTest {
-    IPresale.RoundConfig[] internal _newRounds;
-    uint256 internal _totalRounds;
+    event RoundsUpdated(IPresale.RoundConfig[] prevRounds, IPresale.RoundConfig[] newRounds, address indexed sender);
+
+    IPresale.RoundConfig[] private _newRounds;
+    uint256 private _totalRounds;
 
     function setUp() public {
         _totalRounds = 10;
-
-        for (uint256 i; i < _totalRounds; ++i) {
+        for (uint256 i; i < 10; ++i) {
             IPresale.RoundConfig memory _round = IPresale.RoundConfig({tokenPrice: i * 10, tokensAllocated: i * 100});
-
             _newRounds.push(_round);
         }
     }
 
-    function test_success() external {}
+    function test_success() external {
+        vm.prank(GLOBAL_ADMIN);
+        presale.setRounds(_newRounds);
 
-    function test_rejects_whenNotOwner() external {}
+        IPresale.RoundConfig[] memory _rounds = presale.rounds();
 
-    function test_emits_RoundsUpdated() external {}
+        for (uint256 i; i < _totalRounds; ++i) {
+            assertEq(_rounds[i].tokenPrice, i * 10);
+            assertEq(_rounds[i].tokensAllocated, i * 100);
+        }
+
+        assertEq(_rounds.length, _totalRounds);
+    }
+
+    function test_should_setCurrentRoundIndex() external {
+        vm.warp(startDate + 1);
+
+        vm.prank(ALICE);
+        presale.purchaseDAI(2100 * USD_PRECISION);
+
+        while (_newRounds.length != 0) {
+            _newRounds.pop();
+        }
+
+        uint256[] memory _tokenPrices = new uint256[](3);
+        _tokenPrices[0] = 70000000000000000;
+        _tokenPrices[1] = 70000000000000000;
+        _tokenPrices[2] = 80000000000000000;
+
+        for (uint256 i; i < 3; ++i) {
+            IPresale.RoundConfig memory _round =
+                IPresale.RoundConfig({tokenPrice: _tokenPrices[i], tokensAllocated: 10_000 * PRECISION});
+            _newRounds.push(_round);
+        }
+
+        vm.prank(GLOBAL_ADMIN);
+        presale.setRounds(_newRounds);
+
+        assertEq(presale.currentRoundIndex(), 2);
+    }
+
+    function test_rejects_whenNotOwner() external {
+        vm.expectRevert("Ownable: caller is not the owner");
+
+        vm.prank(ALICE);
+        presale.setRounds(_newRounds);
+    }
+
+    function test_emits_RoundsUpdated() external assertEvent {
+        vm.prank(GLOBAL_ADMIN);
+        emit RoundsUpdated(rounds, _newRounds, GLOBAL_ADMIN);
+        presale.setRounds(_newRounds);
+    }
 }
 
 contract PresaleTest_purchase is PresaleTest {
-    function test_success() external {}
+    event Purchase(
+        uint256 indexed roundIndex,
+        address indexed asset,
+        uint256 tokenPrice,
+        uint256 amountAsset,
+        uint256 amountUSD,
+        uint256 tokensAllocated,
+        address indexed sender
+    );
 
-    function test_rejects_whenPaused() external {}
+    uint256[] private _purchaseAmountsUSD;
+    uint256 private _totalCostUSD;
+    uint256 private _totalAllocation;
 
-    function test_rejects_whenRaiseNotStarted() external {}
+    uint256 private _aliceEthBalance;
+    uint256 private _withdrawToEthBalance;
 
-    function test_rejects_whenRaiseEnded() external {}
+    function setUp() public {
+        _purchaseAmountsUSD = [700, 700, 800, 800, 900, 900, 200];
+    }
 
-    function test_rejects_whenMinDepositAmount() external {}
+    function test_success() external {
+        _aliceEthBalance = ALICE.balance;
+        _withdrawToEthBalance = address(config.withdrawTo).balance;
 
-    function test_emits_Receipt() external {}
+        vm.warp(startDate + 1);
+
+        vm.prank(ALICE);
+        presale.purchase{value: 2.5 ether}(); // 5k usd worth
+
+        for (uint256 i; i < _purchaseAmountsUSD.length; ++i) {
+            IPresale.RoundConfig memory _round = presale.round(i);
+            uint256 _roundAllocation = _purchaseAmountsUSD[i] * (USD_PRECISION * PRECISION) / _round.tokenPrice;
+            _totalAllocation += _roundAllocation;
+
+            uint256 _tokenCostUSD = _roundAllocation * _round.tokenPrice / PRECISION;
+            _totalCostUSD += _tokenCostUSD;
+        }
+
+        assertEq(presale.totalRaisedUSD(), _totalCostUSD);
+        assertEq(presale.userTokensAllocated(ALICE), _totalAllocation);
+
+        assertEq(ALICE.balance, _aliceEthBalance - (_totalCostUSD / 2_000));
+        assertEq(address(config.withdrawTo).balance, _withdrawToEthBalance + (_totalCostUSD / 2_000));
+    }
+
+    function test_rejects_whenPaused() external {
+        vm.prank(GLOBAL_ADMIN);
+        presale.pause();
+
+        vm.expectRevert("Pausable: paused");
+
+        vm.prank(ALICE);
+        presale.purchase{value: 2.5 ether}();
+    }
+
+    function test_rejects_whenRaiseNotStarted() external {
+        vm.warp(startDate - 1);
+
+        vm.expectRevert("RAISE_NOT_STARTED");
+
+        vm.prank(ALICE);
+        presale.purchase{value: 2.5 ether}();
+    }
+
+    function test_rejects_whenRaiseEnded() external {
+        vm.warp(endDate + 1);
+
+        vm.expectRevert("RAISE_ENDED");
+
+        vm.prank(ALICE);
+        presale.purchase{value: 2.5 ether}();
+    }
+
+    function test_rejects_whenMinDepositAmount() external {
+        //        vm.warp(startDate + 1);
+        //
+        //        vm.expectRevert("MIN_DEPOSIT_AMOUNT");
+        //
+        //        vm.prank(GLOBAL_ADMIN);
+        //        presale.purchase{value: 1}();
+    }
+
+    function test_emits_Purchase() external assertEvent {
+        vm.warp(startDate + 1);
+
+        for (uint256 i; i < _purchaseAmountsUSD.length; ++i) {
+            IPresale.RoundConfig memory _round = presale.round(i);
+            uint256 _roundAllocation = _purchaseAmountsUSD[i] * (USD_PRECISION * PRECISION) / _round.tokenPrice;
+            _totalAllocation += _roundAllocation;
+
+            uint256 _tokenCostUSD = _roundAllocation * _round.tokenPrice / PRECISION;
+            _totalCostUSD += _tokenCostUSD;
+
+            emit Purchase(
+                i,
+                address(0),
+                _round.tokenPrice,
+                _tokenCostUSD * 2.5 ether / 5_000 ether,
+                _tokenCostUSD,
+                _roundAllocation,
+                ALICE
+            );
+        }
+
+        vm.prank(ALICE);
+        presale.purchase{value: 2.5 ether}();
+    }
 }
 
 contract PresaleTest_purchaseForAccount is PresaleTest {
-    function test_success() external {}
+    function test_success() external {
+        vm.prank();
+    }
 
     function test_rejects_whenPaused() external {}
 
@@ -328,6 +639,20 @@ contract PresaleTest_purchaseUSDC is PresaleTest {
 }
 
 contract PresaleTest_purchaseDAI is PresaleTest {
+    function test_success() external {}
+
+    function test_rejects_whenPaused() external {}
+
+    function test_rejects_whenRaiseNotStarted() external {}
+
+    function test_rejects_whenRaiseEnded() external {}
+
+    function test_rejects_whenMinDepositAmount() external {}
+
+    function test_emits_Receipt() external {}
+}
+
+contract PresaleTest_allocate is PresaleTest {
     function test_success() external {}
 
     function test_rejects_whenPaused() external {}

--- a/foundry/tests/Presale.t.sol
+++ b/foundry/tests/Presale.t.sol
@@ -527,7 +527,7 @@ contract PresaleTest_purchase is PresaleTest {
         vm.warp(startDate + 1);
 
         vm.prank(ALICE);
-        presale.purchase{value: 2.5 ether}(); // 5k usd worth
+        presale.purchase{value: 2.5 ether}();
 
         for (uint256 i; i < _purchaseAmountsUSD.length; ++i) {
             IPresale.RoundConfig memory _round = presale.round(i);
@@ -574,12 +574,12 @@ contract PresaleTest_purchase is PresaleTest {
     }
 
     function test_rejects_whenMinDepositAmount() external {
-        //        vm.warp(startDate + 1);
-        //
-        //        vm.expectRevert("MIN_DEPOSIT_AMOUNT");
-        //
-        //        vm.prank(GLOBAL_ADMIN);
-        //        presale.purchase{value: 1}();
+        vm.warp(startDate + 1);
+
+        vm.expectRevert("MIN_DEPOSIT_AMOUNT");
+
+        vm.prank(GLOBAL_ADMIN);
+        presale.purchase{value: 0.0004 ether}();
     }
 
     function test_emits_Purchase() external assertEvent {

--- a/foundry/tests/Presale.t.sol
+++ b/foundry/tests/Presale.t.sol
@@ -75,20 +75,23 @@ contract PresaleTest is Test {
 
         config = IPresale.PresaleConfig({
             minDepositAmount: 1,
-            maxUserAllocation: 10_000 ether,
+            maxUserAllocation: uint128(70_000 * PRECISION),
             startDate: startDate,
             endDate: endDate,
             withdrawTo: withdrawTo
         });
 
+        // tokenPrice = how many tokens for 1 usd
+        // tokens allocated in round = _roundRemaining * tokenPrice;
+
         tokenPrices = [
-            14285714285700000000,
-            14285714285700000000,
-            12500000000000000000,
-            12500000000000000000,
-            11111111111100000000,
-            11111111111100000000,
-            10000000000000000000
+            70000000000000000,
+            70000000000000000,
+            80000000000000000,
+            80000000000000000,
+            90000000000000000,
+            90000000000000000,
+            100000000000000000
         ];
 
         for (uint256 i; i < totalRounds; ++i) {
@@ -98,6 +101,7 @@ contract PresaleTest is Test {
                 tokenPrice: tokenPrices[i],
                 tokensAllocated: tokensAllocated[i]
             });
+
             rounds.push(_round);
         }
 

--- a/foundry/tests/Presale.t.sol
+++ b/foundry/tests/Presale.t.sol
@@ -557,21 +557,18 @@ contract PresaleTest_purchase is PresaleTest {
     uint256 private _totalCostUSD;
     uint256 private _totalAllocation;
 
-    uint256 private _alicePurchaseAmountUSD;
     uint256 private _aliceTotalCostUSD;
-
-    uint256 private _bobPurchaseAmountUSD;
     uint256 private _bobTotalCostUSD;
 
     function test_success(uint256 _alicePurchaseAmountETH, uint256 _bobPurchaseAmountETH) external {
         vm.assume(_alicePurchaseAmountETH != 0);
         vm.assume(_bobPurchaseAmountETH != 0);
 
-        _alicePurchaseAmountETH = bound(_alicePurchaseAmountETH, 1 ether, _aliceEthBalance);
-        _bobPurchaseAmountETH = bound(_bobPurchaseAmountETH, 1 ether, _bobEthBalance);
+        _alicePurchaseAmountETH = bound(_alicePurchaseAmountETH, 1 ether, aliceEthBalance);
+        _bobPurchaseAmountETH = bound(_bobPurchaseAmountETH, 1 ether, bobEthBalance);
 
-        _alicePurchaseAmountUSD = _alicePurchaseAmountETH * 2000;
-        _bobPurchaseAmountUSD = _bobPurchaseAmountETH * 2000;
+        uint256 _alicePurchaseAmountUSD = _alicePurchaseAmountETH * (presale.ethPrice() / PRECISION);
+        uint256 _bobPurchaseAmountUSD = _bobPurchaseAmountETH * (presale.ethPrice() / PRECISION);
 
         vm.warp(startDate);
 
@@ -588,7 +585,7 @@ contract PresaleTest_purchase is PresaleTest {
                 _roundAllocation = _roundAllocationRemaining;
             }
 
-            _aliceAllocationRemaining -= _roundAllocation;
+            aliceAllocationRemaining -= _roundAllocation;
 
             uint256 _tokenCostUSD = _roundAllocation * _round.tokenPrice / PRECISION;
 
@@ -606,10 +603,10 @@ contract PresaleTest_purchase is PresaleTest {
         presale.purchase{value: _alicePurchaseAmountETH}();
 
         assertEq(presale.totalRaisedUSD(), _totalCostUSD);
-        assertEq(presale.userTokensAllocated(ALICE), config.maxUserAllocation - _aliceAllocationRemaining);
+        assertEq(presale.userTokensAllocated(ALICE), config.maxUserAllocation - aliceAllocationRemaining);
 
-        assertEq(ALICE.balance, _aliceEthBalance - (_aliceTotalCostUSD / 2_000));
-        assertEq(address(config.withdrawTo).balance, _withdrawToEthBalance + (_totalCostUSD / 2_000));
+        assertEq(ALICE.balance, aliceEthBalance - (_aliceTotalCostUSD / 2_000));
+        assertEq(address(config.withdrawTo).balance, withdrawToEthBalance + (_totalCostUSD / 2_000));
 
         for (uint256 i = presale.currentRoundIndex(); i < totalRounds; ++i) {
             IPresale.RoundConfig memory _round = presale.round(i);
@@ -626,7 +623,7 @@ contract PresaleTest_purchase is PresaleTest {
                 _roundAllocation = _roundAllocationRemaining;
             }
 
-            _bobAllocationRemaining -= _roundAllocation;
+            bobAllocationRemaining -= _roundAllocation;
 
             uint256 _tokenCostUSD = _roundAllocation * _round.tokenPrice / PRECISION;
 
@@ -644,10 +641,10 @@ contract PresaleTest_purchase is PresaleTest {
         presale.purchase{value: _bobPurchaseAmountETH}();
 
         assertEq(presale.totalRaisedUSD(), _totalCostUSD);
-        assertEq(presale.userTokensAllocated(BOB), config.maxUserAllocation - _bobAllocationRemaining);
+        assertEq(presale.userTokensAllocated(BOB), config.maxUserAllocation - bobAllocationRemaining);
 
-        assertEq(BOB.balance, _bobEthBalance - (_bobTotalCostUSD / 2_000));
-        assertEq(address(config.withdrawTo).balance, _withdrawToEthBalance + (_totalCostUSD / 2_000));
+        assertEq(BOB.balance, bobEthBalance - (_bobTotalCostUSD / 2_000));
+        assertEq(address(config.withdrawTo).balance, withdrawToEthBalance + (_totalCostUSD / 2_000));
     }
 
     function test_rejects_whenPaused() external {
@@ -688,9 +685,8 @@ contract PresaleTest_purchase is PresaleTest {
     }
 
     function test_emits_Purchase() external assertEvent {
-        _alicePurchaseAmountUSD = 1_234 ether;
-
-        uint256 _alicePurchaseAmountETH = _alicePurchaseAmountUSD / 2000;
+        uint256 _alicePurchaseAmountUSD = 1_234 ether;
+        uint256 _alicePurchaseAmountETH = _alicePurchaseAmountUSD / (presale.ethPrice() / PRECISION);
 
         vm.warp(startDate);
 
@@ -775,7 +771,7 @@ contract PresaleTest_purchaseForAccount is PresaleTest {
                 _roundAllocation = _roundAllocationRemaining;
             }
 
-            _aliceAllocationRemaining -= _roundAllocation;
+            aliceAllocationRemaining -= _roundAllocation;
 
             uint256 _tokenCostUSD = _roundAllocation * _round.tokenPrice / PRECISION;
 
@@ -793,10 +789,10 @@ contract PresaleTest_purchaseForAccount is PresaleTest {
         presale.purchase{value: _alicePurchaseAmountETH}(ALICE);
 
         assertEq(presale.totalRaisedUSD(), _totalCostUSD);
-        assertEq(presale.userTokensAllocated(ALICE), config.maxUserAllocation - _aliceAllocationRemaining);
+        assertEq(presale.userTokensAllocated(ALICE), config.maxUserAllocation - aliceAllocationRemaining);
 
-        assertEq(ALICE.balance, _aliceEthBalance);
-        assertEq(address(config.withdrawTo).balance, _withdrawToEthBalance);
+        assertEq(ALICE.balance, aliceEthBalance);
+        assertEq(address(config.withdrawTo).balance, withdrawToEthBalance);
 
         for (uint256 i = presale.currentRoundIndex(); i < totalRounds; ++i) {
             IPresale.RoundConfig memory _round = presale.round(i);
@@ -813,7 +809,7 @@ contract PresaleTest_purchaseForAccount is PresaleTest {
                 _roundAllocation = _roundAllocationRemaining;
             }
 
-            _bobAllocationRemaining -= _roundAllocation;
+            bobAllocationRemaining -= _roundAllocation;
 
             uint256 _tokenCostUSD = _roundAllocation * _round.tokenPrice / PRECISION;
 
@@ -831,10 +827,10 @@ contract PresaleTest_purchaseForAccount is PresaleTest {
         presale.purchase{value: _bobPurchaseAmountETH}(BOB);
 
         assertEq(presale.totalRaisedUSD(), _totalCostUSD);
-        assertEq(presale.userTokensAllocated(BOB), config.maxUserAllocation - _bobAllocationRemaining);
+        assertEq(presale.userTokensAllocated(BOB), config.maxUserAllocation - bobAllocationRemaining);
 
-        assertEq(BOB.balance, _bobEthBalance);
-        assertEq(address(config.withdrawTo).balance, _withdrawToEthBalance);
+        assertEq(BOB.balance, bobEthBalance);
+        assertEq(address(config.withdrawTo).balance, withdrawToEthBalance);
     }
 
     function test_rejects_whenPaused() external {
@@ -875,7 +871,7 @@ contract PresaleTest_purchaseForAccount is PresaleTest {
     }
 
     function test_emits_Purchase() external assertEvent {
-        _alicePurchaseAmountUSD = 3_333 ether;
+        uint256 _alicePurchaseAmountUSD = 3_333 ether;
         uint256 _alicePurchaseAmountETH = _alicePurchaseAmountUSD / (presale.ethPrice() / PRECISION);
 
         vm.warp(startDate);
@@ -933,36 +929,19 @@ contract PresaleTest_purchaseUSDC is PresaleTest {
     uint256 private _totalCostUSD;
     uint256 private _totalAllocation;
 
-    uint256 private _alicePurchaseAmountUSD;
-//    uint256 private _alicePurchaseAmountAsset;
     uint256 private _aliceTotalCostUSD;
-    uint256 private _aliceAllocationRemaining;
-
-    uint256 private _bobPurchaseAmountUSD;
-//    uint256 private _bobPurchaseAmountAsset;
     uint256 private _bobTotalCostUSD;
-    uint256 private _bobAllocationRemaining;
 
-    uint256 private _aliceUsdcBalance;
-    uint256 private _bobUsdcBalance;
-    uint256 private _withdrawToUsdcBalance;
+    function test_success(uint256 _alicePurchaseAmountAsset, uint256 _bobPurchaseAmountAsset) external {
+        vm.assume(_alicePurchaseAmountAsset != 0);
+        vm.assume(_bobPurchaseAmountAsset != 0);
 
-    function setUp() public {
-//        _alicePurchaseAmountUSD = 2_345 ether;
-//        _alicePurchaseAmountAsset = 2_345 * 1e6;
-//
-//        _bobPurchaseAmountUSD = 5_678 ether;
-//        _bobPurchaseAmountAsset = 5_678 * 1e6;
+        _alicePurchaseAmountAsset = bound(_alicePurchaseAmountAsset, 1e6, aliceUsdcBalance);
+        _bobPurchaseAmountAsset = bound(_bobPurchaseAmountAsset, 1e6, bobUsdcBalance);
 
-        _aliceAllocationRemaining = config.maxUserAllocation;
-        _bobAllocationRemaining = config.maxUserAllocation;
+        uint256 _alicePurchaseAmountUSD = _alicePurchaseAmountAsset * USDC_SCALE;
+        uint256 _bobPurchaseAmountUSD = _bobPurchaseAmountAsset * USDC_SCALE;
 
-        _aliceUsdcBalance = USDC.balanceOf(ALICE);
-        _bobUsdcBalance = USDC.balanceOf(BOB);
-        _withdrawToUsdcBalance = USDC.balanceOf(config.withdrawTo);
-    }
-
-    function test_success() external {
         vm.warp(startDate);
 
         for (uint256 i = presale.currentRoundIndex(); i < totalRounds; ++i) {
@@ -978,7 +957,7 @@ contract PresaleTest_purchaseUSDC is PresaleTest {
                 _roundAllocation = _roundAllocationRemaining;
             }
 
-            _aliceAllocationRemaining -= _roundAllocation;
+            aliceAllocationRemaining -= _roundAllocation;
 
             uint256 _tokenCostUSD = _roundAllocation * _round.tokenPrice / PRECISION;
 
@@ -996,10 +975,10 @@ contract PresaleTest_purchaseUSDC is PresaleTest {
         presale.purchaseUSDC(_alicePurchaseAmountAsset);
 
         assertEq(presale.totalRaisedUSD(), _totalCostUSD);
-        assertEq(presale.userTokensAllocated(ALICE), config.maxUserAllocation - _aliceAllocationRemaining);
+        assertEq(presale.userTokensAllocated(ALICE), config.maxUserAllocation - aliceAllocationRemaining);
 
-        assertEq(USDC.balanceOf(ALICE), _aliceUsdcBalance - (_aliceTotalCostUSD / USDC_SCALE));
-        assertEq(USDC.balanceOf(config.withdrawTo), _withdrawToUsdcBalance + (_totalCostUSD / USDC_SCALE));
+        assertEq(USDC.balanceOf(ALICE), aliceUsdcBalance - (_aliceTotalCostUSD / USDC_SCALE));
+        assertEq(USDC.balanceOf(config.withdrawTo), withdrawToUsdcBalance + (_totalCostUSD / USDC_SCALE));
 
         for (uint256 i = presale.currentRoundIndex(); i < totalRounds; ++i) {
             IPresale.RoundConfig memory _round = presale.round(i);
@@ -1016,7 +995,7 @@ contract PresaleTest_purchaseUSDC is PresaleTest {
                 _roundAllocation = _roundAllocationRemaining;
             }
 
-            _bobAllocationRemaining -= _roundAllocation;
+            bobAllocationRemaining -= _roundAllocation;
 
             uint256 _tokenCostUSD = _roundAllocation * _round.tokenPrice / PRECISION;
 
@@ -1034,10 +1013,10 @@ contract PresaleTest_purchaseUSDC is PresaleTest {
         presale.purchaseUSDC(_bobPurchaseAmountAsset);
 
         assertEq(presale.totalRaisedUSD(), _totalCostUSD);
-        assertEq(presale.userTokensAllocated(BOB), config.maxUserAllocation - _bobAllocationRemaining);
+        assertEq(presale.userTokensAllocated(BOB), config.maxUserAllocation - bobAllocationRemaining);
 
-        assertEq(USDC.balanceOf(BOB), _bobUsdcBalance - (_bobTotalCostUSD / USDC_SCALE));
-        assertEq(USDC.balanceOf(config.withdrawTo), _withdrawToUsdcBalance + (_totalCostUSD / USDC_SCALE));
+        assertEq(USDC.balanceOf(BOB), bobUsdcBalance - (_bobTotalCostUSD / USDC_SCALE));
+        assertEq(USDC.balanceOf(config.withdrawTo), withdrawToUsdcBalance + (_totalCostUSD / USDC_SCALE));
     }
 
     function test_rejects_whenPaused() external {
@@ -1078,6 +1057,9 @@ contract PresaleTest_purchaseUSDC is PresaleTest {
     }
 
     function test_emits_Receipt() external {
+        uint256 _alicePurchaseAmountAsset = 1_345 * 1e6;
+        uint256 _alicePurchaseAmountUSD = _alicePurchaseAmountAsset * USDC_SCALE;
+
         vm.warp(startDate);
 
         for (uint256 i = presale.currentRoundIndex(); i < totalRounds; ++i) {


### PR DESCRIPTION
Changes to contract:

- renamed `Receipt` event to `Purchase` because Foundry lib has a clashing variable name
- re-ordered `Purchase` event params
- added `ethToTokens()`
- added missing `pause()` and `unpause()` overrides
- `setRounds()` wasnt properly removing the prevRounds, so changed for loop pop() to a while loop which fixed it
- added break to `_sync` and decrement incrementer `if _roundAllocation == 0`
- updated setting of currentRoundIndex in _sync, since the incrementer will be equal to totalRounds length if the last round is reached and for loop ends, but we want it to be equal to `totalRounds length - 1`
- updated `_send` function's account param, since we want to refund remaining funds to `msg.sender` and not account being credited with tokenAllocation when `purchase(address account)` is being called
- renamed `_totalPurchaseAmountAsset` in `_sync` to `_totalCostAsset`
- created memory instance of `RoundConfig` for each iteration of incoming newRounds array in `setRounds()`